### PR TITLE
Remove user access to twitter command.

### DIFF
--- a/src/bot/commands/util/twitter.ts
+++ b/src/bot/commands/util/twitter.ts
@@ -36,6 +36,7 @@ class TwitterCommand extends Command {
           default: null,
         },
       ],
+      ownerOnly: true,
       category: "util",
       ratelimit: 1,
       cooldown: 600000,


### PR DESCRIPTION
With the deletion of the twitter API key, this is required to ensure people don't try to use the command until it is fixed later on.